### PR TITLE
 Fix JavaUtilPropertySource NPE

### DIFF
--- a/src/main/java/info/macias/kaconf/sources/AbstractPropertySource.java
+++ b/src/main/java/info/macias/kaconf/sources/AbstractPropertySource.java
@@ -18,6 +18,8 @@ package info.macias.kaconf.sources;
 import info.macias.kaconf.ConfiguratorException;
 import info.macias.kaconf.PropertySource;
 
+import java.net.URI;
+import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -63,7 +65,8 @@ public abstract class AbstractPropertySource implements PropertySource {
             entry(float.class, Float::valueOf),
             entry(Double.class, Double::valueOf),
             entry(double.class, Double::valueOf),
-            entry(String.class, value->value)
+            entry(String.class, value->value),
+            entry(URI.class, URI::create)
     ) .collect(Collectors.toMap((e) -> e.getKey(), (e) -> e.getValue())));
 
 

--- a/src/main/java/info/macias/kaconf/sources/JavaUtilPropertySource.java
+++ b/src/main/java/info/macias/kaconf/sources/JavaUtilPropertySource.java
@@ -15,6 +15,7 @@
 */
 package info.macias.kaconf.sources;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +29,7 @@ public class JavaUtilPropertySource extends AbstractPropertySource {
     private Properties properties;
 
     /**
-     * <p>Instantiates the class by loading a {@link java.util.Properties} specified as argument.</p>
+     * <p>Instantiates the class by loading the File specified as argument.</p>
      * <p>If the {@link java.util.Properties} cannot be loaded (e.g. because the file does not exist or
      * the user does not have permissions), no exceptions will be thrown and the object will be
      * instantiated anyway. However, the {@link JavaUtilPropertySource#isAvailable()} method will
@@ -36,12 +37,29 @@ public class JavaUtilPropertySource extends AbstractPropertySource {
      * @param filePath The path to reach the Properties file.
      */
     public JavaUtilPropertySource(String filePath) {
-        try(FileInputStream fis = new FileInputStream(filePath)) {
-            properties.load(fis);
+        this(new File(filePath));
+    }
+
+    /**
+     * <p>Instantiates the class by loading the File specified as argument.</p>
+     * <p>If the {@link java.util.Properties} cannot be loaded (e.g. because the file does not exist or
+     * the user does not have permissions), no exceptions will be thrown and the object will be
+     * instantiated anyway. However, the {@link JavaUtilPropertySource#isAvailable()} method will
+     * return <code>false</code>.</p>
+     * @param filePath The path to reach the Properties file.
+     */
+    public JavaUtilPropertySource(File file) {
+        if (file == null || !file.isFile())
+            throw new IllegalArgumentException("'" + file + "' is not a valid file.");
+        try(FileInputStream fis = new FileInputStream(file)) {
+            Properties props = new Properties();
+            props.load(fis);
+            properties = props;
         } catch (IOException e) {
             properties = null;
         }
     }
+
     /**
      * <p>Instantiates the class by loading the {@link java.util.Properties} object that is
      * reachable by the {@link InputStream} specified as argument</p>
@@ -53,7 +71,9 @@ public class JavaUtilPropertySource extends AbstractPropertySource {
      */
     public JavaUtilPropertySource(InputStream is) {
         try {
-            properties.load(is);
+            Properties props = new Properties();
+            props.load(is);
+            properties = props;
         } catch (NullPointerException | IOException e) {
             properties = null;
         }

--- a/src/test/kotlin/info/macias/kaconf/sources/JavaUtilPropertySourceTest.kt
+++ b/src/test/kotlin/info/macias/kaconf/sources/JavaUtilPropertySourceTest.kt
@@ -1,10 +1,10 @@
 package info.macias.kaconf.sources
 
-import info.macias.kaconf.Configurator
 import info.macias.kaconf.ConfiguratorBuilder
 import info.macias.kaconf.Property
 import org.junit.Test
 import java.io.File
+import java.net.URI
 import java.net.URL
 import kotlin.test.assertEquals
 
@@ -14,6 +14,9 @@ class JavaUtilPropertySourceTest {
 
         @Property("project.name")
         var name: String? = null
+
+        @Property("project.uri")
+        val uri: URI? = null
     }
 
     @Test
@@ -30,6 +33,7 @@ class JavaUtilPropertySourceTest {
         configurator.configure(project)
 
         assertEquals("kaconf", project.name)
+        assertEquals("https://github.com/mariomac/kaconf", project.uri)
     }
 
     @Test
@@ -45,5 +49,6 @@ class JavaUtilPropertySourceTest {
         configurator.configure(project)
 
         assertEquals("kaconf", project.name)
+        assertEquals("https://github.com/mariomac/kaconf", project.uri)
     }
 }

--- a/src/test/kotlin/info/macias/kaconf/sources/JavaUtilPropertySourceTest.kt
+++ b/src/test/kotlin/info/macias/kaconf/sources/JavaUtilPropertySourceTest.kt
@@ -1,0 +1,49 @@
+package info.macias.kaconf.sources
+
+import info.macias.kaconf.Configurator
+import info.macias.kaconf.ConfiguratorBuilder
+import info.macias.kaconf.Property
+import org.junit.Test
+import java.io.File
+import java.net.URL
+import kotlin.test.assertEquals
+
+class JavaUtilPropertySourceTest {
+
+    class Project {
+
+        @Property("project.name")
+        var name: String? = null
+    }
+
+    @Test
+    fun `test can create source from InputStream`() {
+        var source : JavaUtilPropertySource? = null
+        javaClass.getResourceAsStream("/javautil.properties").use {
+            source = JavaUtilPropertySource(it)
+        }
+
+        val project = Project()
+        val configurator = ConfiguratorBuilder()
+                .addSource(source!!)
+                .build()
+        configurator.configure(project)
+
+        assertEquals("kaconf", project.name)
+    }
+
+    @Test
+    fun `test can create source from File`() {
+        val res: URL = javaClass.getResource("/javautil.properties")
+        val f = File(res.toURI())
+        val source = JavaUtilPropertySource(f)
+
+        val project = Project()
+        val configurator = ConfiguratorBuilder()
+                .addSource(source)
+                .build()
+        configurator.configure(project)
+
+        assertEquals("kaconf", project.name)
+    }
+}

--- a/src/test/resources/javautil.properties
+++ b/src/test/resources/javautil.properties
@@ -1,2 +1,3 @@
 
 project.name=kaconf
+project.uri=https://github.com/mariomac/kaconf

--- a/src/test/resources/javautil.properties
+++ b/src/test/resources/javautil.properties
@@ -1,0 +1,2 @@
+
+project.name=kaconf


### PR DESCRIPTION
Hi!

I was using the `JavaUtilPropertySource` as source, and got NPEs when passing `String`, or `InputStream` as argument. This PR fixes those. I also added a `Converter` for `URI`.

Although I added unit tests to complement them, I can't run the tests (or build the project on my end) because the build config requires (your) OSSRH account. I'm not an expert in gradle, so I couldn't update it to exclude deployments on default build.